### PR TITLE
write tests for merge_new_data

### DIFF
--- a/ml4ms/core.py
+++ b/ml4ms/core.py
@@ -22,8 +22,8 @@ class Dataset:
 
 if __name__ == "__main__":
     d = Dataset()
-    d.dataset = {'a': {'a': 1, 'b': 2}, 'b': {'a': 3, 'b': 4}}
-    actual = d.merge_new_data_into_dataset({'a': {'a': 5, 'b': 6}, 'b': {'a': 7, 'b': 8}})
-    expected = {'a': {'a': 5, 'b': 6}, 'b': {'a': 7, 'b': 8}}
-    assert actual == expected
-    print("Passed all tests!")
+    d.dataset = {"a": {"a": 1, "b": 2}, "b": {"a": 3, "b": 4}}
+    d.merge_new_data({"a": {"a": 5, "b": 6}, "b": {"a": 7, "b": 8}})
+    expected = {"a": {"a": 5, "b": 6}, "b": {"a": 7, "b": 8}}
+    assert d.dataset == expected
+    # print("Passed all tests!")

--- a/ml4ms/core.py
+++ b/ml4ms/core.py
@@ -9,7 +9,7 @@ class Dataset:
         Parameters
         ----------
         new_data: dict
-            the first argument is a dictionary with the same format as self.dataset
+            The first argument is a dictionary with the same format as self.dataset
             {mat_id_1 : {attribute_1: , attribute_2:, ...}, ...}
 
         Returns
@@ -17,7 +17,9 @@ class Dataset:
             nothing
         """
         for key, value in new_data.items():
-            self.dataset[key].update(value)
+            # merge only if key exists
+            if key in self.dataset:
+                self.dataset[key].update(value)
 
 
 if __name__ == "__main__":

--- a/ml4ms/tests/test_core.py
+++ b/ml4ms/tests/test_core.py
@@ -1,23 +1,42 @@
 import pytest
+
 from ml4ms.core import Dataset
 
+# datasets in format [(original, to_merge, expected), ()]
 datasets = [
-    #test orthonal datasets
-    ([{'1': {'_id': 1, 'a': 2}, '3': {'_id': 3, 'b': 4}}, {'2': {'_id': 2}}],
-     {'1': {'_id': 1, 'a': 2}, '3': {'_id': 3, 'b': 4}, '2': {'_id': 2}}),
-    # test orthogonal items in intersecting sets
-    ([{'1': {'_id': 1, 'a': 2}, '3': {'_id': 3, 'b': 4}}, {'3': {'_id': 3, 'c': 5}}],
-     {'1': {'_id': 1, 'a': 2}, '3': {'_id': 3, 'b': 4, 'c': 5}}),
+    # test identical datasets
+    (
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}},
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}},
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}},
+    ),
+    # test orthogonal items
+    (
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}},
+        {"3": {"_id": 3, "b": 4}},
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3, "b": 4}},
+    ),
     # test overlapping items in intersecting sets
-    #...
+    (
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}},
+        {"1": {"_id": 1, "a": 3, "b": 3}},  # this should overwrite a['1']
+        {"1": {"_id": 1, "a": 3, "b": 3}, "3": {"_id": 3}},
+    ),
+    # test merging an empty collection
+    ({"1": {"_id": 1, "a": 2}, "3": {"_id": 3}}, {}, {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}}),
     # test the new dataset does not have the right primary key (invalid datasets could maybe be tested elsewhere)
-    # ...
+    (
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}},
+        {"invalid_key": {"_id": "invalid_key"}},
+        {"1": {"_id": 1, "a": 2}, "3": {"_id": 3}},
+    )
     # anything else to test?
 ]
-@pytest.mark.parametrize("ds", datasets)
-def test_merge_new_data(ds):
+
+
+@pytest.mark.parametrize("old_ds, new_ds, expected", datasets)
+def test_merge_new_data(old_ds, new_ds, expected):
     d = Dataset()
-    d.dataset = ds[0][0]
-    d.merge_new_data(ds[0][1])
-    expected = ds[1]
+    d.dataset = old_ds
+    d.merge_new_data(new_ds)
     assert d.dataset == expected


### PR DESCRIPTION
closes #6 
Currently all tests in test_core.py except 'invalid_key' passed (when the existing dataset doesn't have the key found in new_dataset). Let me know if there are other cases I should add to test_core.py.

I need to edit the function to deal with 'invalid_key' cases. Should I do it on this branch and push again (so all the checks/tests pass?)